### PR TITLE
Make sure we never ignore asynchronous exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dist/
 .cabal-sandbox/
 cabal.sandbox.config
 dist-newstyle
+Makefile
 *.tix
 .*.swp
 *~

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+0.2
+
+* Change exception handling semantics to make sure we never ignore
+asynchronous exceptions
 
 0.1.1
 

--- a/io-region.cabal
+++ b/io-region.cabal
@@ -1,5 +1,5 @@
 name:                io-region
-version:             0.1.1
+version:             0.2.0
 synopsis:            Exception safe resource management with dynamic regions
 license:             BSD3
 license-file:        LICENSE
@@ -29,6 +29,7 @@ source-repository head
 
 library
   exposed-modules:     Control.IO.Region
+                       Control.IO.Region.Internal
   build-depends:       base >= 4.5 && < 5.0,
                        stm
   hs-source-dirs:      lib

--- a/io-region.cabal
+++ b/io-region.cabal
@@ -12,15 +12,13 @@ build-type:          Simple
 cabal-version:       >=1.10
 description:
   Region owns resources and automatically frees them on exit.
-  It is a plain old ADT, so it is possible to pass it to functions,
+  It is a plain old data type, so it is possible to pass it to functions,
   put into mutable references, store in regular data types.
   .
   Resources can be freed earler or transfered to other regions.
   .
   Region itself can be used as any other resource. E.g. one region
   can own other one.
-  .
-  The library doesn't pretend to solve double throw issue.
 extra-source-files:  changelog.md
 
 source-repository head

--- a/io-region.cabal
+++ b/io-region.cabal
@@ -6,7 +6,7 @@ license-file:        LICENSE
 author:              Yuras Shumovich
 maintainer:          shumovichy@gmail.com
 copyright:           Copyright (c) Yuras Shumovich 2015
-homepage:            https://github.com/Yuras/io-region/wiki
+homepage:            https://github.com/Yuras/io-region
 category:            Control
 build-type:          Simple
 cabal-version:       >=1.10

--- a/lib/Control/IO/Region.hs
+++ b/lib/Control/IO/Region.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-
 -- | Exception safe resource management
 --
 -- Examples:
@@ -44,8 +42,6 @@ module Control.IO.Region
 (
   Region,
   Key,
-  AlreadyClosed(..),
-  AlreadyFreed(..),
   region,
   open,
   close,
@@ -58,145 +54,13 @@ module Control.IO.Region
 )
 where
 
-import Prelude (($!), Enum(..))
-import Data.Typeable
-import Data.Bool
-import Data.Int
-import Data.Eq
-import Data.Function
-import qualified Data.List as List
-import Data.Tuple
-import Data.Maybe
-import Control.Monad
-import Control.Applicative
-import Control.Exception
 import Control.Concurrent.STM
-import System.IO
-import Text.Show
-
--- | Region owns resources and frees them on close
-data Region = Region {
-  resources :: TVar [(Key, IO ())],
-  closed :: TVar Bool,
-  nextKey :: TVar Int
-  }
-  deriving Eq
-
--- | Each resource is identified by unique key
-data Key = Key {
-  _keyIndex :: Int,
-  keyRegion :: Region,
-  keyFreed :: TVar Bool
-  }
-  deriving Eq
-
--- | Resource not found in the specified region
-data NotFound = NotFound
-  deriving (Show, Typeable)
-
-instance Exception NotFound where
-
--- | Region already closed
-data AlreadyClosed = AlreadyClosed
-  deriving (Show, Typeable)
-
-instance Exception AlreadyClosed where
-
--- | Resource already freed
-data AlreadyFreed = AlreadyFreed
-  deriving (Show, Typeable)
-
-instance Exception AlreadyFreed where
-
--- | Create new region. It will be automatically closed on exit
-region :: (Region -> IO a) -> IO a
-region = bracket open close
-
--- | Open new region. Prefer `region` function.
-open :: IO Region
-open = Region
-     <$> newTVarIO []
-     <*> newTVarIO False
-     <*> newTVarIO 1
-
--- | Close the region. You probably should called it
--- when async exceptions are masked. Prefer `region` function.
--- It is error to close region twice.
---
--- In case of exception inside any cleanup handler, other handlers will be
--- called anyway. The last exception will be rethrown (that matches the
--- behavior of `Control.Exception.bracket`.)
-close :: Region -> IO ()
-close r = do
-  ress <- uninterruptibleMask_ $ atomically $ do
-    guardOpen r
-    ress <- readTVar (resources r)
-    writeTVar (resources r) $! []
-    writeTVar (closed r) True
-    forM_ ress $ \(k, _) ->
-      writeTVar (keyFreed k) True
-    return (List.map snd ress)
-  go ress
-  where
-  go [] = return $! ()
-  go (res:ress) = res `finally` go ress
-
--- | Allocate resource inside the region
-alloc :: Region
-      -> IO a         -- ^ action to allocate resource
-      -> (a -> IO ()) -- ^ action to cleanup resource
-      -> IO (a, Key)  -- ^ the resource and it's key
-alloc r acquire cleanup = mask_ $ do
-  res <- acquire
-  uninterruptibleMask_ $ atomically $ do
-    guardOpen r
-    k <- Key
-      <$> readTVar (nextKey r)
-      <*> pure r
-      <*> newTVar False
-    modifyTVar' (nextKey r) succ
-    modifyTVar' (resources r) ((k, cleanup res) :)
-    return (res, k)
+import Control.IO.Region.Internal
+import Control.Monad
 
 -- | The same as `alloc`, but doesn't return the key
 alloc_ :: Region -> IO a -> (a -> IO ()) -> IO a
 alloc_ r a f = fst <$> alloc r a f
-
--- | Free the resource earlier then it's region will be closed.
--- It will be removed from the region immediately.
--- It is error to free resource twice
-free :: Key -> IO ()
-free k = mask_ $ join $ atomically $ do
-  let r = keyRegion k
-  guardLive k
-  m_res <- List.lookup k <$> readTVar (resources r)
-  case m_res of
-    Nothing -> throwSTM NotFound
-    Just c -> do
-      modifyTVar' (resources r) $ List.filter ((/= k) . fst)
-      writeTVar (keyFreed k) True
-      return c
-
--- | Move resource to other region.
--- The old key becomes invalid and should not be used
-moveToSTM :: Key -> Region -> STM Key
-moveToSTM k r = do
-  guardLive k
-  guardOpen (keyRegion k)
-  m_res <- List.lookup k <$> readTVar (resources $ keyRegion k)
-  case m_res of
-    Nothing -> throwSTM NotFound
-    Just c -> do
-      guardOpen r
-      modifyTVar' (resources $ keyRegion k) $ List.filter ((/= k) . fst)
-      writeTVar (keyFreed k) True
-      k' <- Key
-         <$> readTVar (nextKey r)
-         <*> pure r
-         <*> newTVar False
-      modifyTVar' (nextKey r) succ
-      modifyTVar' (resources r) ((k', c) :)
-      return k'
 
 -- | Move resource to other region. See also `moveToSTM`
 moveTo :: Key -> Region -> IO Key
@@ -205,15 +69,3 @@ moveTo k = atomically . moveToSTM k
 -- | Defer action until region is closed
 defer :: Region -> IO () -> IO ()
 defer r a = void $ alloc_ r (return $! ()) (const a)
-
-guardOpen :: Region -> STM ()
-guardOpen r = do
-  c <- readTVar (closed r)
-  when c $
-    throwSTM AlreadyClosed
-
-guardLive :: Key -> STM ()
-guardLive k = do
-  f <- readTVar (keyFreed k)
-  when f $
-    throwSTM AlreadyFreed

--- a/lib/Control/IO/Region/Internal.hs
+++ b/lib/Control/IO/Region/Internal.hs
@@ -95,17 +95,14 @@ close r = mask_ $ do
 -- | Extended version of `onException`, which ignores synchronous
 -- exceptions from the handler.
 onExceptionEx :: IO a -> IO b -> IO a
-onExceptionEx io h = mask $ \restore ->
-  -- mask above is necessary to make sure asynchronous exception
-  -- won't appear after catching exception, but before handler is executed
-  restore io `catch` \e -> do
-    case fromException e of
-      Just SomeAsyncException{} -> do
-        -- we are handling asynchronous exception, and we don't want another
-        -- one to appear, so mask them hard
-        ignoreExceptions $ uninterruptibleMask_ h
-        throwIO e
-      Nothing -> ignoreExceptions h >> throwIO e
+onExceptionEx io h = io `catch` \e -> do
+  case fromException e of
+    Just SomeAsyncException{} -> do
+      -- we are handling asynchronous exception, and we don't want another
+      -- one to appear, so mask them hard
+      ignoreExceptions $ uninterruptibleMask_ h
+      throwIO e
+    Nothing -> ignoreExceptions h >> throwIO e
 
 -- | Ignore any synchronous exception from the action
 ignoreExceptions :: IO a -> IO ()

--- a/lib/Control/IO/Region/Internal.hs
+++ b/lib/Control/IO/Region/Internal.hs
@@ -1,0 +1,167 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+-- | These module exposes internals of the library
+
+module Control.IO.Region.Internal
+(
+  Region(..),
+  Key(..),
+  AlreadyClosed(..),
+  AlreadyFreed(..),
+  NotFound(..),
+  region,
+  open,
+  close,
+  alloc,
+  free,
+  moveToSTM
+)
+where
+
+import Prelude (($!), Enum(..))
+import Data.Typeable
+import Data.Bool
+import Data.Int
+import Data.Eq
+import Data.Function
+import qualified Data.List as List
+import Data.Tuple
+import Data.Maybe
+import Control.Monad
+import Control.Applicative
+import Control.Exception
+import Control.Concurrent.STM
+import System.IO
+import Text.Show
+
+-- | Region owns resources and frees them on close
+data Region = Region {
+  resources :: TVar [(Key, IO ())],
+  closed :: TVar Bool,
+  nextKey :: TVar Int
+  }
+  deriving Eq
+
+-- | Each resource is identified by unique key
+data Key = Key {
+  keyIndex :: Int,
+  keyRegion :: Region,
+  keyFreed :: TVar Bool
+  }
+  deriving Eq
+
+-- | Resource not found in the specified region
+data NotFound = NotFound
+  deriving (Show, Typeable)
+
+instance Exception NotFound where
+
+-- | Region already closed
+data AlreadyClosed = AlreadyClosed
+  deriving (Show, Typeable)
+
+instance Exception AlreadyClosed where
+
+-- | Resource already freed
+data AlreadyFreed = AlreadyFreed
+  deriving (Show, Typeable)
+
+instance Exception AlreadyFreed where
+
+-- | Create new region. It will be automatically closed on exit
+region :: (Region -> IO a) -> IO a
+region = bracket open close
+
+-- | Open new region. Prefer `region` function.
+open :: IO Region
+open = Region
+     <$> newTVarIO []
+     <*> newTVarIO False
+     <*> newTVarIO 1
+
+-- | Close the region. You probably should called it
+-- when async exceptions are masked. Prefer `region` function.
+-- It is error to close region twice.
+--
+-- In case of exception inside any cleanup handler, other handlers will be
+-- called anyway. The last exception will be rethrown (that matches the
+-- behavior of `Control.Exception.bracket`.)
+close :: Region -> IO ()
+close r = do
+  ress <- uninterruptibleMask_ $ atomically $ do
+    guardOpen r
+    ress <- readTVar (resources r)
+    writeTVar (resources r) $! []
+    writeTVar (closed r) True
+    forM_ ress $ \(k, _) ->
+      writeTVar (keyFreed k) True
+    return (List.map snd ress)
+  go ress
+  where
+  go [] = return $! ()
+  go (res:ress) = res `finally` go ress
+
+-- | Allocate resource inside the region
+alloc :: Region
+      -> IO a         -- ^ action to allocate resource
+      -> (a -> IO ()) -- ^ action to cleanup resource
+      -> IO (a, Key)  -- ^ the resource and it's key
+alloc r acquire cleanup = mask_ $ do
+  res <- acquire
+  uninterruptibleMask_ $ atomically $ do
+    guardOpen r
+    k <- Key
+      <$> readTVar (nextKey r)
+      <*> pure r
+      <*> newTVar False
+    modifyTVar' (nextKey r) succ
+    modifyTVar' (resources r) ((k, cleanup res) :)
+    return (res, k)
+
+-- | Free the resource earlier then it's region will be closed.
+-- It will be removed from the region immediately.
+-- It is error to free resource twice
+free :: Key -> IO ()
+free k = mask_ $ join $ atomically $ do
+  let r = keyRegion k
+  guardLive k
+  m_res <- List.lookup k <$> readTVar (resources r)
+  case m_res of
+    Nothing -> throwSTM NotFound
+    Just c -> do
+      modifyTVar' (resources r) $ List.filter ((/= k) . fst)
+      writeTVar (keyFreed k) True
+      return c
+
+-- | Move resource to other region.
+-- The old key becomes invalid and should not be used
+moveToSTM :: Key -> Region -> STM Key
+moveToSTM k r = do
+  guardLive k
+  guardOpen (keyRegion k)
+  m_res <- List.lookup k <$> readTVar (resources $ keyRegion k)
+  case m_res of
+    Nothing -> throwSTM NotFound
+    Just c -> do
+      guardOpen r
+      modifyTVar' (resources $ keyRegion k) $ List.filter ((/= k) . fst)
+      writeTVar (keyFreed k) True
+      k' <- Key
+         <$> readTVar (nextKey r)
+         <*> pure r
+         <*> newTVar False
+      modifyTVar' (nextKey r) succ
+      modifyTVar' (resources r) ((k', c) :)
+      return k'
+
+guardOpen :: Region -> STM ()
+guardOpen r = do
+  c <- readTVar (closed r)
+  when c $
+    throwSTM AlreadyClosed
+
+guardLive :: Key -> STM ()
+guardLive k = do
+  f <- readTVar (keyFreed k)
+  when f $
+    throwSTM AlreadyFreed

--- a/test/test.hs
+++ b/test/test.hs
@@ -11,6 +11,7 @@ import Control.Monad
 import Control.Monad.IO.Class
 import Control.IO.Region (region)
 import qualified Control.IO.Region as Region
+import qualified Control.IO.Region.Internal as Internal
 
 import Test.Hspec
 
@@ -41,7 +42,7 @@ main = hspec $ do
             r <- Region.open
             Region.close r
             Region.alloc_ r (return ()) (const $ return ())
-      test `shouldThrow` \e -> seq (e :: Region.AlreadyClosed) True
+      test `shouldThrow` \e -> seq (e :: Internal.AlreadyClosed) True
 
   describe "free" $ do
     it "should call cleanup action" $ do
@@ -59,7 +60,7 @@ main = hspec $ do
             (_, k) <- Region.alloc r (return ()) (const $ return ())
             Region.free k
             Region.free k
-      test `shouldThrow` \e -> seq (e :: Region.AlreadyFreed) True
+      test `shouldThrow` \e -> seq (e :: Internal.AlreadyFreed) True
 
   describe "region" $ do
     it "should free resources on exit" $ do
@@ -78,14 +79,14 @@ main = hspec $ do
             (_, k) <- Region.alloc r (return ()) (const $ return ())
             Region.close r
             Region.free k
-      test `shouldThrow` \e -> seq (e :: Region.AlreadyFreed) True
+      test `shouldThrow` \e -> seq (e :: Internal.AlreadyFreed) True
 
     it "should throw when called twice" $ do
       let test = do
             r <- Region.open
             Region.close r
             Region.close r
-      test `shouldThrow` \e -> seq (e :: Region.AlreadyClosed) True
+      test `shouldThrow` \e -> seq (e :: Internal.AlreadyClosed) True
 
   describe "moveTo" $ do
     it "should remove resource from the original region" $ do

--- a/test/test.hs
+++ b/test/test.hs
@@ -54,13 +54,14 @@ main = hspec $ do
           readIORef ref
       res `shouldBe` (12 :: Int)
 
-    it "should throw when called twice" $ do
-      let test = do
-            r <- Region.open
-            (_, k) <- Region.alloc r (return ()) (const $ return ())
-            Region.free k
-            Region.free k
-      test `shouldThrow` \e -> seq (e :: Internal.AlreadyFreed) True
+    context "when called twice" $ do
+      it "should fail" $ do
+        let test = do
+              r <- Region.open
+              (_, k) <- Region.alloc r (return ()) (const $ return ())
+              Region.free k
+              Region.free k
+        test `shouldThrow` \e -> seq (e :: Internal.AlreadyFreed) True
 
   describe "region" $ do
     it "should free resources on exit" $ do
@@ -71,6 +72,17 @@ main = hspec $ do
           (const $ writeIORef ref True)
       res <- liftIO $ readIORef ref
       res `shouldBe` True
+
+    context "when region body fails" $ do
+      it "should free resources" $ do
+        ref <- liftIO $ newIORef False
+        liftIO $ Internal.ignoreExceptions $ region $ \r -> do
+          void $ Region.alloc_ r
+            (return ())
+            (const $ writeIORef ref True)
+          fail "no way"
+        res <- liftIO $ readIORef ref
+        res `shouldBe` True
 
   describe "close" $ do
     it "should free resources" $ do
@@ -88,15 +100,87 @@ main = hspec $ do
             Region.close r
       test `shouldThrow` \e -> seq (e :: Internal.AlreadyClosed) True
 
+    it "should allow cleanups to be interrupted" $ do
+      ref <- liftIO $ newIORef Unmasked
+      r <- Region.open
+      void $ Region.alloc_ r
+        (return ())
+        (const $ getMaskingState >>= writeIORef ref)
+      Region.close r
+      res <- liftIO $ readIORef ref
+      res `shouldBe` MaskedInterruptible
+
+    context "when cleanup fails" $
+      it "should free other resources" $ do
+        ref <- liftIO $ newIORef 0
+        r <- Region.open
+        void $ Region.alloc_ r
+          (return ())
+          (const $ modifyIORef' ref succ)
+        void $ Region.alloc_ r
+          (return ())
+          (const $ fail "no way")
+        void $ Region.alloc_ r
+          (return ())
+          (const $ modifyIORef' ref succ)
+        Internal.ignoreExceptions $ Region.close r
+        res <- liftIO $ readIORef ref
+        res `shouldBe` 2
+
+    context "when cleanup throws async exception" $ do
+      it "should free other resources" $ do
+        ref <- liftIO $ newIORef 0
+        r <- Region.open
+        void $ Region.alloc_ r
+          (return ())
+          (const $ modifyIORef' ref succ)
+        void $ Region.alloc_ r
+          (return ())
+          (const $ throwIO UserInterrupt)
+        void $ Region.alloc_ r
+          (return ())
+          (const $ modifyIORef' ref succ)
+        Region.close r
+          `catch` \e -> seq (e :: SomeException) (return ())
+        res <- liftIO $ readIORef ref
+        res `shouldBe` 2
+
+      it "should rethrow the async exception" $ do
+        r <- Region.open
+        void $ Region.alloc_ r
+          (return ())
+          (const $ fail "no way")
+        void $ Region.alloc_ r
+          (return ())
+          (const $ throwIO UserInterrupt)
+        void $ Region.alloc_ r
+          (return ())
+          (const $ fail "no way")
+        Region.close r
+          `shouldThrow` (== UserInterrupt)
+
+      it "should not allow subsequent cleanups to be interrupted" $ do
+        ref <- liftIO $ newIORef Unmasked
+        r <- Region.open
+        void $ Region.alloc_ r
+          (return ())
+          (const $ getMaskingState >>= writeIORef ref)
+        void $ Region.alloc_ r
+          (return ())
+          (const $ throwIO UserInterrupt)
+        Region.close r
+          `catch` \e -> seq (e :: SomeException) (return ())
+        res <- liftIO $ readIORef ref
+        res `shouldBe` MaskedUninterruptible
+
   describe "moveTo" $ do
     it "should remove resource from the original region" $ do
-      let test = do
-            r <- Region.open
-            (_, k) <- Region.alloc r (return ()) (const $ return ())
-            r' <- Region.open
-            void $ k `Region.moveTo` r'
-            Region.free k
-      test `shouldThrow` \e -> seq (e :: SomeException) True
+      r <- Region.open
+      (_, k) <- Region.alloc r (return ()) (const $ return ())
+      r' <- Region.open
+      void $ k `Region.moveTo` r'
+      Region.free k
+        `shouldThrow` \Internal.AlreadyFreed -> True
 
     it "should move resource to other region" $ do
       r <- Region.open
@@ -104,6 +188,15 @@ main = hspec $ do
       r' <- Region.open
       k' <- k `Region.moveTo` r'
       Region.free k'
+
+    context "when target region is closed" $ do
+      it "should fail" $ do
+        r <- Region.open
+        (_, k) <- Region.alloc r (return ()) (const $ return ())
+        r' <- Region.open
+        Region.close r'
+        Region.moveTo k r'
+          `shouldThrow` \Internal.AlreadyClosed -> True
 
   describe "defer" $ do
     it "should add the action to region to be called on close" $ do

--- a/test/test.hs
+++ b/test/test.hs
@@ -84,6 +84,24 @@ main = hspec $ do
         res <- liftIO $ readIORef ref
         res `shouldBe` True
 
+    context "when region body throws asynchronous exception" $ do
+      it "should rethrow one" $ do
+        let action = Region.region $ \r -> do
+              Region.alloc_ r
+                (return ())
+                (const $ fail "no")
+              throwIO UserInterrupt
+        action `shouldThrow` \UserInterrupt -> True
+
+    context "when cleanup throws asynchronous exception" $ do
+      it "should rethrow one" $ do
+        let action = Region.region $ \r -> do
+              Region.alloc_ r
+                (return ())
+                (const $ throwIO UserInterrupt)
+              fail "no"
+        action `shouldThrow` \UserInterrupt -> True
+
   describe "close" $ do
     it "should free resources" $ do
       let test = do


### PR DESCRIPTION
Consider the following situation. An exception was raised, and now we want to de-allocate some resources. But cleanup action for one of them throws an exception too, and now we have a choice: which one to propagate further and which one, accordingly, to ignore. See for example [here](https://github.com/fpco/safe-exceptions#exceptions-in-cleanup-code) for some details. 

Both choices are bad because the other one might be asynchronous one, and ignoring asynchronous exceptions is a bad idea.

The obvious solution is to check which one is asynchronous and propagate it. It won't work because both might be asynchronous! The only way around is to make sure we'll never get two asynchronous exceptions as the same time, i.e. use `uninterruptibleMask` where necessary.

It's known that `uninterruptibleMask` might cause unexpected deadlocks and other issues, that's why it's important to use it only when strictly necessary. In `safe-exceptions` [it was decided](https://github.com/fpco/safe-exceptions/issues/3) to wrap all cleanup actions into `uninterruptibleMask`, but it's too brutal. We need it only in the case when we already propagating asynchronous exception.
